### PR TITLE
Método para comprobar si un recurso pertenece a un email

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -1,13 +1,16 @@
 from google.appengine.ext import db
+import util
 
 
 class Serie(db.Model):
-
     title = db.StringProperty()
     score = db.IntegerProperty()
     author_name = db.StringProperty()
     author_email = db.EmailProperty()
     views = db.IntegerProperty()
+
+    def belongs_to(self, user_email):
+        return util.is_authorized(user_email, self.author_email)
 
 
 class Sketch(db.Model):
@@ -16,6 +19,9 @@ class Sketch(db.Model):
     score = db.IntegerProperty()
     serie = db.ReferenceProperty(Serie, collection_name='sketches')
 
+    def belongs_to(self, user_email):
+        return util.is_authorized(user_email, self.serie.author_email)
+
 
 class Comment(db.Model):
     author_name = db.StringProperty()
@@ -23,3 +29,6 @@ class Comment(db.Model):
     text = db.StringProperty(required=True, multiline=True)
     lastEdit = db.DateTimeProperty(auto_now=True)
     sketch = db.ReferenceProperty(Sketch, collection_name='comments', required=True)
+
+    def belongs_to(self, user_email):
+        return util.is_authorized(user_email, self.author_email)

--- a/src/templates/sketches/list.html
+++ b/src/templates/sketches/list.html
@@ -1,6 +1,5 @@
 <!-- Usa todo el espacio disponible -->
 <div>
-
     <h3>Vi&ntilde;etas {{ sketches.count() if  sketches.count() > 0 else ""}}</h3>
     {% if sketches and sketches.count() > 0%}
 
@@ -23,13 +22,14 @@
                     <!-- En badge: el número de comentarios -->
                     <span class="badge">{{ sk.comments.count() }}</span> <span class="glyphicon glyphicon-comment"></span>
                 </a>
+                {% if sk.belongs_to(user_email) %}
                 <a  href="/sketches/edit/{{ sk.key().id() }}" class="btn btn-warning">
                     <span class="glyphicon glyphicon-pencil"></span>
                 </a>
                 <a  href="/sketches/delete/{{ sk.key().id() }}" class="btn btn-danger">
                     <span class="glyphicon glyphicon-trash"></span>
                 </a>
-
+                {% endif %}
             </td>
         </tr>
     {% endfor %}

--- a/src/util.py
+++ b/src/util.py
@@ -1,0 +1,6 @@
+# coding=utf-8
+
+
+def is_authorized(usr_email, owner_email):
+    """isAuthorized comprueba que el recurso pertenece al usuario, o el usuario está autorizado."""
+    return usr_email == owner_email or usr_email == 'pruebaparaingweb@gmail.com'

--- a/src/views.py
+++ b/src/views.py
@@ -38,6 +38,8 @@ class BaseHandler(webapp2.RequestHandler):
             **template_args
     ):
         template_values['logged'] = self.session.get('logged')
+        template_values['user_email'] = self.session.get('user_email')
+        template_values['user_name'] = self.session.get('user_name')
         template = jinja_environment.get_template(filename)
         self.response.out.write(template.render(template_values))
 


### PR DESCRIPTION
Se necesita el email del usuario y se aplica sobre series, sketches y comments. 
Sin embargo, solo se ha aplicado en un lugar a modo de demostración de uso.